### PR TITLE
feat: Add timestamp to rsynced outputfolders

### DIFF
--- a/modules/rsync/src/hooks.py
+++ b/modules/rsync/src/hooks.py
@@ -3,11 +3,12 @@
 from functools import partial
 from logging import LoggerAdapter
 from pathlib import Path
+from time import strftime
 
 from cellophane import cfg, data, executors, modules
 from humanfriendly import parse_size
 
-from .util import sync_callback
+from .util import sync_callback, add_timestamp
 
 ROOT = Path(__file__).parent.parent
 
@@ -41,7 +42,10 @@ def rsync_results(
         "dir": [],
     }
 
+    timestamp = strftime('%y%m%d-%H%M%S')
     for output in samples.output:
+        logger.debug(f"Adding timestamp to {output.dst}")
+        output.dst = add_timestamp(Path(config.resultdir), output.dst, timestamp)
         if not output.src.exists():
             logger.warning(f"{output.src} does not exist")
             continue

--- a/modules/rsync/src/util.py
+++ b/modules/rsync/src/util.py
@@ -25,3 +25,16 @@ def sync_callback(
             logger.debug(f"Copied {src} -> {dst}")
         else:
             logger.warning(f"{dst} is missing")
+
+def add_timestamp(
+        resultdir: Path,
+        dst: Path,
+        timestamp: str,
+) -> Path:
+    """Add datetag to outputfolder."""
+    if dst.is_relative_to(resultdir):
+        # Unique outputfolder for each sample located after resultdir
+        dst_parts = dst.relative_to(resultdir).parts
+        dst_name_with_tag = f"{dst_parts[0]}_{timestamp}"
+        dst = resultdir / dst_name_with_tag / Path(*dst_parts[1:])
+    return dst


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Add timestamp to the rsynced outputfolder(s).

### The Why
Avoid overwriting. Avoid mixing broken output from crashed samples being mixed with output from reruns.

### The How
Added function add_timestamp to rsync module.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome
Timestamp on rsynced output folder.