### PR TITLE
feat: Paginate SLIMS fetch

### DIFF
--- a/modules/slims_/__init__.py
+++ b/modules/slims_/__init__.py
@@ -1,5 +1,6 @@
 """SLIMS module for cellophane."""
 
+from .src.connection import PaginatedSlims
 from .src.hooks import slims_fetch, slims_sync_post, slims_sync_pre
 from .src.mixins import SlimsSample, SlimsSamples
 from .src.util import (
@@ -24,4 +25,5 @@ __all__ = [
     "validate_criteria",
     "SlimsSample",
     "SlimsSamples",
+    "PaginatedSlims",
 ]

--- a/modules/slims_/schema.yaml
+++ b/modules/slims_/schema.yaml
@@ -65,3 +65,8 @@ properties:
         description: Do not sync data to SLIMS
         default: false
         type: boolean
+
+      page_size:
+        description: Page size to use when fetching records from SLIMS
+        default: 100
+        type: integer

--- a/modules/slims_/src/connection.py
+++ b/modules/slims_/src/connection.py
@@ -1,0 +1,76 @@
+from typing import Any, Iterator
+
+from slims.slims import Criterion, Record, Slims
+
+
+class PaginatedSlims(Slims):
+    def __init__(
+        self,
+        name: str,
+        url: str,
+        username: str | None = None,
+        password: str | None = None,
+        oauth: bool = False,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        repo_location: str | None = None,
+        local_host: str = "localhost",
+        local_port: int = 5000,
+        page_size: int = 100,
+        **request_params: Any
+    ) -> None:
+        self.page_size = page_size
+        super().__init__(
+            name=name,
+            url=url,
+            username=username,
+            password=password,
+            oauth=oauth,
+            client_id=client_id,
+            client_secret=client_secret,
+            repo_location=repo_location,
+            local_host=local_host,
+            local_port=local_port,
+            **request_params
+        )
+
+    def fetch(
+        self,
+        table: str,
+        criteria: Criterion,
+        sort: list[str] | None = None,
+        start: int | None = None,
+        end: int | None = None,
+    ) -> list[Record]:
+        return [
+            record
+            for page in self.iter_fetch(
+                table=table,
+                criteria=criteria,
+                sort=sort,
+                start=start,
+                end=end,
+            )
+            for record in page
+        ]
+
+    def iter_fetch(
+        self,
+        table: str,
+        criteria: Criterion,
+        sort: list[str] | None = None,
+        start: int | None = None,
+        end: int | None = None,
+    ) -> Iterator[list[Record]]:
+        _start = start or 0
+        _end = end or float("inf")
+
+        while _page := super().fetch(
+            table=table,
+            criteria=criteria,
+            sort=sort,
+            start=_start,
+            end=min(_end, _start + self.page_size),
+        ):
+            yield _page
+            _start += self.page_size

--- a/modules/slims_/src/hooks.py
+++ b/modules/slims_/src/hooks.py
@@ -8,8 +8,8 @@ from warnings import warn
 from cellophane import Config, Samples, post_hook, pre_hook
 from humanfriendly import parse_timespan
 from slims.internal import Record
-from slims.slims import Slims
 
+from .connection import PaginatedSlims
 from .mixins import SlimsSample, SlimsSamples
 from .util import get_records
 
@@ -55,11 +55,12 @@ def slims_fetch(
         logger.warning("No SLIMS criteria - Skipping fetch")
         return None
 
-    slims_connection = Slims(
+    slims_connection = PaginatedSlims(
         name=__package__,
         url=config.slims.url,
         username=config.slims.username,
         password=config.slims.password,
+        page_size=config.slims.page_size,
     )
 
     if samples:
@@ -82,6 +83,7 @@ def slims_fetch(
         criteria=criteria,
         connection=slims_connection,
     )
+
     if not records:
         logger.warning("No SLIMS records found")
         return None

--- a/modules/slims_/tests/__init__.py
+++ b/modules/slims_/tests/__init__.py
@@ -53,14 +53,23 @@ def fetch_factory(
     db_ = db or []
     fields_ = fields or [f for r in db_ for f in dir(r) if f.startswith("cntn_")]
 
-    def fetch(conn: Any, table: str, criteria: Criterion):
-        del conn  # Unused
+    def fetch(
+        conn: Any,
+        table: str,
+        criteria: Criterion,
+        sort: list[str] | None = None,
+        start: int | None = None,
+        end: int | None = None,
+    ):
+        del conn, sort  # Unused
 
         logger.debug("Mocking fetch from from table '%s'", table)
-        if table == "Field":
-            return not db_ or criteria.to_dict()["value"] in fields_
+        if table == "Field" and not fields:
+            return [criteria.to_dict()["value"]][start:end]
+        elif table == "Field":
+            return [f for f in fields_ if f == criteria.to_dict()["value"]][start:end]
         logger.debug("Criteria: %s", criteria.to_dict())
-        match = [r for r in db_ if _match_criteria(criteria, r)]
+        match = [r for r in db_ if _match_criteria(criteria, r)][start:end]
         logger.debug("Matched %s records", len(match))
         return match
 

--- a/modules/slims_/tests/criteria.yaml
+++ b/modules/slims_/tests/criteria.yaml
@@ -502,6 +502,7 @@ id: invalid_field
 criteria: cntn_INVALID equals a
 records:
   - !!python/object/apply:slims_.tests.RecordMock []
+fields: ["cntn_VALID"]
 exception: !!python/name:ValueError
 
 ---

--- a/modules/slims_/tests/test_slims.py
+++ b/modules/slims_/tests/test_slims.py
@@ -21,7 +21,7 @@ class Test_integration:
 class Test_criteria:
     @staticmethod
     @mark.parametrize(
-        "criteria,parsed,unnested,resolved,exception,records,kwargs",
+        "criteria,parsed,unnested,resolved,exception,records,fields,kwargs",
         [
             param(
                 d["criteria"],
@@ -30,6 +30,7 @@ class Test_criteria:
                 d.get("resolved"),
                 d.get("exception"),
                 d.get("records"),
+                d.get("fields", None),
                 d.get("kwargs", {}),
                 id=d["id"],
             )
@@ -44,11 +45,12 @@ class Test_criteria:
         resolved,
         exception,
         records,
+        fields,
         kwargs,
     ):
         mocker.patch(
             "slims.slims.Slims.fetch",
-            new=slims_.tests.fetch_factory(records or []),
+            new=slims_.tests.fetch_factory(records or [], fields=fields),
         )
         conn = Slims("DUMMY", url="DUMMY", username="DUMMY", password="DUMMY")
         if exception:


### PR DESCRIPTION
### The What
Perform SLIMS fetch in pages, rather than all at once..

### The Why
Queries resulting in large responses from SLIMS can crash the server. Fetching results in pages mitigates the problem.

### The How
This PR adds a `PaginatedSlims` class, overriding the fetch method to iterate over pages of configurable size. It is a drop-in replacement for `slims.Slims`. An `iter_fetch` method is also provided, exposing the underlying iterator, which yields one page of results at a time.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
