### PR TITLE
refactor: Improve grid_engine logging

### DIFF
--- a/modules/grid_engine/src/executor.py
+++ b/modules/grid_engine/src/executor.py
@@ -11,6 +11,14 @@ from cellophane import Executor
 _GE_JOBS: dict[UUID, dict[UUID, tuple[drmaa2.JobSession, drmaa2.Job]]] = {}
 
 
+def _destroy_ge_session(session: drmaa2.JobSession, logger: logging.LoggerAdapter) -> None:
+    if session.name is not None and session.name in drmaa2.JobSession.list_session_names():
+        try:
+            session.close()
+            session.destroy()
+        except drmaa2.Drmaa2Exception as exc:
+            logger.warning(f"Caught an exception while closing SGE session ({session.name=}): {exc!r}")
+
 @define(slots=False, init=False)
 class GridEngineExecutor(Executor, name="grid_engine"):  # type: ignore[call-arg]
     """Executor using grid engine."""
@@ -80,9 +88,10 @@ class GridEngineExecutor(Executor, name="grid_engine"):  # type: ignore[call-arg
             ) is None:  # pragma: no cover
                 sleep(1)
 
-        if session is not None:
-            session.close()
-            session.destroy()
+        if uuid in self.ge_jobs:
+            session, _ = self.ge_jobs[uuid]
+            _destroy_ge_session(session, logger)
+            del self.ge_jobs[uuid]
 
         raise SystemExit(exit_status)
 
@@ -99,14 +108,6 @@ class GridEngineExecutor(Executor, name="grid_engine"):  # type: ignore[call-arg
                     "Caught an exception while terminating SGE job "
                     f"({job.id=}): {exc!r}"
                 )
-            try:
-                session.close()
-                session.destroy()
-            except drmaa2.Drmaa2Exception as exc:
-                logger.warning(
-                    "Caught an exception while closing SGE session "
-                    f"({session.name=}): {exc!r}"
-                )
-
+            _destroy_ge_session(session, logger)
             del self.ge_jobs[uuid]
         return 143

--- a/modules/grid_engine/src/executor.py
+++ b/modules/grid_engine/src/executor.py
@@ -7,6 +7,7 @@ from uuid import UUID
 import drmaa2
 from attrs import define
 from cellophane import Executor
+from cellophane.util import freeze_logs
 
 _GE_JOBS: dict[UUID, dict[UUID, tuple[drmaa2.JobSession, drmaa2.Job]]] = {}
 
@@ -17,7 +18,7 @@ def _destroy_ge_session(session: drmaa2.JobSession, logger: logging.LoggerAdapte
             session.close()
             session.destroy()
         except drmaa2.Drmaa2Exception as exc:
-            logger.warning(f"Caught an exception while closing SGE session ({session.name=}): {exc!r}")
+            logger.warning(f"Caught an exception while closing Grid Engine session '{session.name=}': {exc!r}")
 
 @define(slots=False, init=False)
 class GridEngineExecutor(Executor, name="grid_engine"):  # type: ignore[call-arg]
@@ -39,15 +40,21 @@ class GridEngineExecutor(Executor, name="grid_engine"):  # type: ignore[call-arg
         os_env: bool = True,
         logger: logging.LoggerAdapter,
         cpus: int,
+        stdout: Path | None = None,
+        stderr: Path | None = None,
         **kwargs: Any,
     ) -> None:
         del kwargs  # Unused
-        _logdir = self.config.logdir / "grid_engine" / uuid.hex
-        _logdir.mkdir(exist_ok=True, parents=True)
+        _name = f"{name}_{uuid.hex[:8]}"
+        # NOTE: Thw stdout and stderr kwargs will be added in a feature release of cellophane.
+        # This is a workaround to remain compatible with the 1.1.x and earlier versions.
+        _stdout = stdout or workdir / f"{_name}.grid_engine.out"
+        _stderr = stderr or workdir / f"{_name}.grid_engine.err"
 
         session = None
+        exit_status: int | None = None
         try:
-            session = drmaa2.JobSession(f"{name}_{uuid.hex}")
+            session = drmaa2.JobSession(_name)
             job = session.run_job(
                 {
                     "remote_command": args[0],
@@ -64,29 +71,24 @@ class GridEngineExecutor(Executor, name="grid_engine"):  # type: ignore[call-arg
                     },
                     "job_name": f"{name}_{uuid.hex[:8]}",
                     "job_environment": env,
-                    "output_path": str(_logdir / f"{name}.out"),
-                    "error_path": str(_logdir / f"{name}.err"),
+                    "output_path": str(_stdout),
+                    "error_path": str(_stderr),
                     "working_directory": str(workdir),
                 }
             )
-            logger.debug(f"Grid Engine job started ({name=}, {uuid=}, {job.id=})")
+            logger.debug(f"Grid Engine job started ({_name}, {job.id=})")
             self.ge_jobs[uuid] = (session, job)
         except drmaa2.Drmaa2Exception as exception:
-            logger.error(f"Failed to submit job to Grid Engine ({name=}, {uuid=})")
+            logger.error(f"Failed to submit job to Grid Engine ({_name})")
             logger.debug(f"Message: {exception}", exc_info=exception)
-            with open(
-                _logdir / f"{name}.err",
-                mode="w",
-                encoding="utf-8",
-            ) as f:
-                f.write(str(exception))
-
+            _stderr.write_text(str(exception))
             exit_status = 1
         else:
-            while (
-                exit_status := job.get_info().exit_status
-            ) is None:  # pragma: no cover
+            while exit_status is None:
+                with freeze_logs():
+                    exit_status = job.get_info().exit_status
                 sleep(1)
+
 
         if uuid in self.ge_jobs:
             session, _ = self.ge_jobs[uuid]
@@ -99,14 +101,12 @@ class GridEngineExecutor(Executor, name="grid_engine"):  # type: ignore[call-arg
         if uuid in self.ge_jobs:
             session, job = self.ge_jobs[uuid]
             try:
-                logger.debug(f"Terminating SGE job (id={job.id})")
                 job.terminate()
                 job.wait_terminated()
-                logger.debug(f"SGE job terminated (id={job.id})")
+                logger.debug(f"Grid Engine job '{job.job_name}' (id={job.id}) terminated")
             except drmaa2.Drmaa2Exception as exc:
                 logger.warning(
-                    "Caught an exception while terminating SGE job "
-                    f"({job.id=}): {exc!r}"
+                    f"Caught an exception while terminating Grid Engine job '{job.job_name}' ({job.id=}): {exc!r}"
                 )
             _destroy_ge_session(session, logger)
             del self.ge_jobs[uuid]

--- a/modules/grid_engine/tests/__init__.py
+++ b/modules/grid_engine/tests/__init__.py
@@ -35,6 +35,7 @@ class JobMock:
 class JobSessionMock:
     state: int = drmaa2.JobState.DONE
     delay: int = 0
+    name: str = "DUMMY"
 
     def close(self, *args, **kwargs):
         del args, kwargs  # Unusedc

--- a/modules/grid_engine/tests/__init__.py
+++ b/modules/grid_engine/tests/__init__.py
@@ -18,6 +18,7 @@ class JobMock:
     state: int = drmaa2.JobState.DONE
     delay: int = 0
     id: str = "DUMMY"
+    job_name: str = "DUMMY"
 
     def get_info(self, *args, **kwargs):
         del args, kwargs

--- a/modules/grid_engine/tests/integration.yaml
+++ b/modules/grid_engine/tests/integration.yaml
@@ -68,4 +68,4 @@
     --executor_name: grid_engine
   logs:
     - "Terminating job with uuid"
-    - "Terminating SGE job (id=DUMMY)"
+    - "Terminating Grid Engine job (DUMMY, id=DUMMY)"


### PR DESCRIPTION
## Contents

### The What
Log stdout/stderr to files in the working directory with names that are easier to find  

### The Why
Finding the correct stdout/stderr log for a specific wrapper invocation and executor job is a bit involved, and often requires reading the debug log. By placing the log-files in the same directory as the job was executed, and giving it a more sane name, finding the logs should be a lot easier.

The logging directory was also flooded with logs, and it is non-trivial to mark each log for cleaning. The wrapper working directory is automatically cleaned on successful runs, so by moving the log-files there they will also be automatically cleaned up.

### The How
- Include name and UUID in executor log-file paths
- Also include name and UUID in all log messages
- Move log files to directly under workdir

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions