### PR TITLE
feat: Use conda spec for nextflow

### DIFF
--- a/modules/nextflow/schema.yaml
+++ b/modules/nextflow/schema.yaml
@@ -28,3 +28,14 @@ properties:
         type: mapping
         description: Environment variables that will be passed to the nextflow process
         default: {}
+      conda:
+        channels:
+          type: array
+          description: Conda channel
+          default:
+            - bioconda
+        dependencies:
+          type: array
+          description:
+          default:
+            - nextflow >= 23.04.3, < 24.0.0

--- a/modules/nextflow/src/util.py
+++ b/modules/nextflow/src/util.py
@@ -60,6 +60,10 @@ def nextflow(
         uuid=uuid_,
         name=name,
         cpus=config.nextflow.threads,
+        conda_spec={
+            "dependencies": config.nextflow.conda.dependencies,
+            "channels": config.nextflow.conda.channels,
+        },
         **kwargs,
     )
 


### PR DESCRIPTION
### The What

Define a conda spec for submitting nextflow jobs.

### The Why

Gives better control over what nextflow version is used, and avoids users having to manually ensure it exists in the execution environment.

### The How

Use `conda_spec` when calling `executor.submit`.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
