### PR TITLE
fix: Graceful destruction of DRMAA job session

### DIFF
--- a/modules/grid_engine/src/executor.py
+++ b/modules/grid_engine/src/executor.py
@@ -11,6 +11,14 @@ from cellophane import Executor
 _GE_JOBS: dict[UUID, dict[UUID, tuple[drmaa2.JobSession, drmaa2.Job]]] = {}
 
 
+def _destroy_ge_session(session: drmaa2.JobSession, logger: logging.LoggerAdapter) -> None:
+    if session.name is not None and session.name in drmaa2.JobSession.list_session_names():
+        try:
+            session.close()
+            session.destroy()
+        except drmaa2.Drmaa2Exception as exc:
+            logger.warning(f"Caught an exception while closing SGE session ({session.name=}): {exc!r}")
+
 @define(slots=False, init=False)
 class GridEngineExecutor(Executor, name="grid_engine"):  # type: ignore[call-arg]
     """Executor using grid engine."""
@@ -80,9 +88,10 @@ class GridEngineExecutor(Executor, name="grid_engine"):  # type: ignore[call-arg
             ) is None:  # pragma: no cover
                 sleep(1)
 
-        if session is not None:
-            session.close()
-            session.destroy()
+        if uuid in self.ge_jobs:
+            session, _ = self.ge_jobs[uuid]
+            _destroy_ge_session(session, logger)
+            del self.ge_jobs[uuid]
 
         raise SystemExit(exit_status)
 
@@ -99,14 +108,6 @@ class GridEngineExecutor(Executor, name="grid_engine"):  # type: ignore[call-arg
                     "Caught an exception while terminating SGE job "
                     f"({job.id=}): {exc!r}"
                 )
-            try:
-                session.close()
-                session.destroy()
-            except drmaa2.Drmaa2Exception as exc:
-                logger.warning(
-                    "Caught an exception while closing SGE session "
-                    f"({session.name=}): {exc!r}"
-                )
-
+            _destroy_ge_session(session, logger)
             del self.ge_jobs[uuid]
         return 143

--- a/modules/grid_engine/tests/__init__.py
+++ b/modules/grid_engine/tests/__init__.py
@@ -35,6 +35,7 @@ class JobMock:
 class JobSessionMock:
     state: int = drmaa2.JobState.DONE
     delay: int = 0
+    name: str = "DUMMY"
 
     def close(self, *args, **kwargs):
         del args, kwargs  # Unusedc


### PR DESCRIPTION
## Contents

### The What
Handle destruction of the DRMAA job session more gracefully.

### The Why
The previous approach was a bit ham-fisted, and would often try to destroy job sessions that no longer existed in grid engine. This resulted in lots of warning messages about various exceptions when jobs were terminated for one reason or another.

### The How
Implement a cleanup function that will destroy a `drmaa2.JobSession` only if it still exists in grid engine. This function is called when a job exits normally, or when `GridEngineExecutor.terminate_hook`is called.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
