### PR TITLE
Grid engine logging

### DIFF
--- a/modules/grid_engine/src/executor.py
+++ b/modules/grid_engine/src/executor.py
@@ -1,14 +1,15 @@
 import logging
 from pathlib import Path
 from time import sleep
+from traceback import format_exception
 from typing import Any
 from uuid import UUID
 
 import drmaa2
 from attrs import define
-from cellophane import Executor
+from cellophane import Executor, util
 
-_GE_JOBS: dict[UUID, dict[UUID, tuple[drmaa2.JobSession, drmaa2.Job]]] = {}
+_GE_JOBS: dict[UUID, dict[UUID, tuple[drmaa2.JobSession, drmaa2.Job, str]]] = {}
 
 
 def _destroy_ge_session(session: drmaa2.JobSession, logger: logging.LoggerAdapter) -> None:
@@ -17,14 +18,14 @@ def _destroy_ge_session(session: drmaa2.JobSession, logger: logging.LoggerAdapte
             session.close()
             session.destroy()
         except drmaa2.Drmaa2Exception as exc:
-            logger.warning(f"Caught an exception while closing SGE session ({session.name=}): {exc!r}")
+            logger.warning(f"Exception while closing Grid Engine session '{session.name=}': {exc!r}")
 
 @define(slots=False, init=False)
 class GridEngineExecutor(Executor, name="grid_engine"):  # type: ignore[call-arg]
     """Executor using grid engine."""
 
     @property
-    def ge_jobs(self) -> dict[UUID, tuple[drmaa2.JobSession, drmaa2.Job]]:
+    def ge_jobs(self) -> dict[UUID, tuple[drmaa2.JobSession, drmaa2.Job, str]]:
         if self.uuid not in _GE_JOBS:
             _GE_JOBS[self.uuid] = {}
         return _GE_JOBS[self.uuid]
@@ -39,13 +40,18 @@ class GridEngineExecutor(Executor, name="grid_engine"):  # type: ignore[call-arg
         os_env: bool = True,
         logger: logging.LoggerAdapter,
         cpus: int,
+        stdout: Path | None = None,
+        stderr: Path | None = None,
         **kwargs: Any,
     ) -> None:
         del kwargs  # Unused
-        _logdir = self.config.logdir / "grid_engine" / uuid.hex
-        _logdir.mkdir(exist_ok=True, parents=True)
+        # NOTE: Thw stdout and stderr kwargs will be added in a feature release of cellophane.
+        # This is a workaround to remain compatible with the 1.1.x and earlier versions.
+        _stdout = stdout or workdir / f"{name}.{uuid.hex}.grid_engine.out"
+        _stderr = stderr or workdir / f"{name}.{uuid.hex}.grid_engine.err"
 
         session = None
+        exit_status: int | None = None
         try:
             session = drmaa2.JobSession(f"{name}_{uuid.hex}")
             job = session.run_job(
@@ -62,31 +68,26 @@ class GridEngineExecutor(Executor, name="grid_engine"):  # type: ignore[call-arg
                             f"{'-V' if os_env else ''}"
                         ),
                     },
-                    "job_name": f"{name}_{uuid.hex[:8]}",
+                    "job_name": f"{name}_{uuid.hex}",
                     "job_environment": env,
-                    "output_path": str(_logdir / f"{name}.out"),
-                    "error_path": str(_logdir / f"{name}.err"),
+                    "output_path": str(_stdout),
+                    "error_path": str(_stderr),
                     "working_directory": str(workdir),
                 }
             )
-            logger.debug(f"Grid Engine job started ({name=}, {uuid=}, {job.id=})")
-            self.ge_jobs[uuid] = (session, job)
-        except drmaa2.Drmaa2Exception as exception:
-            logger.error(f"Failed to submit job to Grid Engine ({name=}, {uuid=})")
-            logger.debug(f"Message: {exception}", exc_info=exception)
-            with open(
-                _logdir / f"{name}.err",
-                mode="w",
-                encoding="utf-8",
-            ) as f:
-                f.write(str(exception))
-
+            logger.debug(f"Submitted job '{name}' to Grid Engine (UUID={uuid.hex[:8]} JID={job.id})")
+            self.ge_jobs[uuid] = (session, job, name)
+        except drmaa2.Drmaa2Exception as exc:
+            logger.error(f"Failed to submit job '{name}' to Grid Engine (UUID={uuid.hex[:8]}): {exc!r}")
+            with open(_stderr, "a", encoding="utf-8") as err:
+                err.writelines(format_exception(type(exc), exc, exc.__traceback__))
             exit_status = 1
         else:
-            while (
-                exit_status := job.get_info().exit_status
-            ) is None:  # pragma: no cover
+            while exit_status is None:
+                with util.freeze_logs():
+                    exit_status = job.get_info().exit_status
                 sleep(1)
+
 
         if uuid in self.ge_jobs:
             session, _, _ = self.ge_jobs[uuid]
@@ -97,17 +98,16 @@ class GridEngineExecutor(Executor, name="grid_engine"):  # type: ignore[call-arg
 
     def terminate_hook(self, uuid: UUID, logger: logging.LoggerAdapter) -> int:
         if uuid in self.ge_jobs:
-            session, job = self.ge_jobs[uuid]
+            session, job, name = self.ge_jobs[uuid]
             try:
-                logger.debug(f"Terminating SGE job (id={job.id})")
                 job.terminate()
                 job.wait_terminated()
-                logger.debug(f"SGE job terminated (id={job.id})")
+                logger.debug(f"Terminated Grid Engine job '{name}' (UUID={uuid.hex[:8]} JID={job.id})")
             except drmaa2.Drmaa2Exception as exc:
                 logger.warning(
-                    "Caught an exception while terminating SGE job "
-                    f"({job.id=}): {exc!r}"
+                    f"Exception while terminating Grid Engine job '{name}' (UUID={uuid.hex[:8]} JID={job.id}): {exc!r}"
                 )
-            _destroy_ge_session(session, logger)
-            del self.ge_jobs[uuid]
+            finally:
+                _destroy_ge_session(session, logger)
+                del self.ge_jobs[uuid]
         return 143

--- a/modules/grid_engine/tests/__init__.py
+++ b/modules/grid_engine/tests/__init__.py
@@ -35,6 +35,7 @@ class JobMock:
 class JobSessionMock:
     state: int = drmaa2.JobState.DONE
     delay: int = 0
+    name: str = "DUMMY"
 
     def close(self, *args, **kwargs):
         del args, kwargs  # Unusedc

--- a/modules/grid_engine/tests/__init__.py
+++ b/modules/grid_engine/tests/__init__.py
@@ -18,6 +18,7 @@ class JobMock:
     state: int = drmaa2.JobState.DONE
     delay: int = 0
     id: str = "DUMMY"
+    job_name: str = "DUMMY"
 
     def get_info(self, *args, **kwargs):
         del args, kwargs

--- a/modules/grid_engine/tests/integration.yaml
+++ b/modules/grid_engine/tests/integration.yaml
@@ -12,14 +12,15 @@
             executor.submit("DUMMY")
             executor.wait()
   mocks:
+    cellophane.executors.executor.uuid4:
+      return_value: !!python/object/apply:uuid.UUID ["deadbeefdeadbeefdeadbeefdeadbeef"]
     modules.grid_engine.src.executor.drmaa2.JobSession:
       return_value: !!python/object/apply:grid_engine.tests.JobSessionMock {}
   args:
     --workdir: work
     --executor_name: grid_engine
   logs:
-    - "Grid Engine job started"
-    - "Job completed"
+    - Submitted job 'grid_engine' to Grid Engine (UUID=deadbeef JID=DUMMY)
 
 - id: grid_engine_exception
   external:
@@ -61,11 +62,12 @@
             executor.wait()
 
   mocks:
+    cellophane.executors.executor.uuid4:
+      return_value: !!python/object/apply:uuid.UUID ["deadbeefdeadbeefdeadbeefdeadbeef"]
     modules.grid_engine.src.executor.drmaa2.JobSession:
       return_value: !!python/object/apply:grid_engine.tests.JobSessionMock {kwds: {delay: 5}}
   args:
     --workdir: work
     --executor_name: grid_engine
   logs:
-    - "Terminating job with uuid"
-    - "Terminating SGE job (id=DUMMY)"
+    - "Terminated Grid Engine job 'grid_engine' (UUID=deadbeef JID=DUMMY)"


### PR DESCRIPTION
## Contents

### The What
Several improvements to Grid Engine executor logging.

### The Why
Logging for the grid engine executor was confusing and often redundant. A large portion of the debug log consisted only of messages emitted when polling running jobs to see if they had exited.

### The How
- Graceful destruction of `drmaa2.JobSession`, avoiding destruction of non-existing sessions
- Suppress logs when polling jobs for status to prevent log-spam
- Use `stdout` and `stderr` keyword arguments in the `target` method (will be added in the next cellophane release)
- Provide more information about jobs in error messages


### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
