### PR TITLE
refactor: Improve nexflow logging and directory structure

### DIFF
--- a/modules/nextflow/scripts/nextflow.sh
+++ b/modules/nextflow/scripts/nextflow.sh
@@ -14,5 +14,6 @@ _clean () {
 trap _clean HUP INT QUIT ABRT USR1 USR2 ALRM TERM
 
 eval "${_NXF_INIT}"
+cd "${_NXF_LAUNCH}"
 NXF_HOME="${TMPDIR}/.nextflow" nextflow $@ & _nxf_pid=$!
 wait $_nxf_pid

--- a/modules/nextflow/src/util.py
+++ b/modules/nextflow/src/util.py
@@ -1,7 +1,6 @@
 """Module for fetching files from HCP."""
 
 from pathlib import Path
-from typing import Callable
 from uuid import UUID, uuid4
 
 from cellophane import cfg, executors
@@ -19,22 +18,22 @@ def nextflow(
     env: dict[str, str] | None = None,
     nxf_config: Path | None = None,
     nxf_work: Path | None = None,
+    nxf_launch: Path | None = None,
     nxf_profile: str | None = None,
     nxf_log: Path | None = None,
     ansi_log: bool = False,
     resume: bool = False,
     name: str = "nextflow",
     check: bool = True,
-    callback: Callable | None = None,
     **kwargs,
 ) -> tuple[AsyncResult, UUID]:
     """Submit a Nextflow job to SGE."""
 
     uuid_ = uuid4()
-    _nxf_log = nxf_log or config.logdir / "nextflow" / f"{name}.{uuid_.hex}.log"
+    _nxf_log = nxf_log or workdir / f"{name}.{uuid_.hex}.nextflow.log"
     _nxf_config = nxf_config or config.nextflow.get("config")
     _nxf_work = nxf_work or config.nextflow.get("workdir") or workdir / "nxf_work"
-    _nxf_launch = workdir / "nxf_launch"
+    _nxf_launch = nxf_launch or config.nextflow.get("launch_dir") or workdir / "nxf_launch"
     _nxf_profile = nxf_profile or config.nextflow.get("profile")
 
     _nxf_log.parent.mkdir(parents=True, exist_ok=True)
@@ -48,15 +47,16 @@ def nextflow(
         "-ansi-log false" if not ansi_log or config.nextflow.ansi_log else "",
         f"-work-dir {_nxf_work}",
         "-resume" if resume else "",
-        f"-with-report {config.logdir / 'nextflow' / f'{name}.{uuid_.hex}.report.html'}",
+        f"-with-report {workdir / f'{name}.{uuid_.hex}.report.html'}",
         (f"-profile {_nxf_profile}" if _nxf_profile else ""),
         *args,
         env={
             "_NXF_INIT": config.nextflow.init,
+            "_NXF_LAUNCH": str(_nxf_launch),
             **config.nextflow.env,
             **(env or {}),
         },
-        workdir=_nxf_launch,
+        workdir=workdir,
         uuid=uuid_,
         name=name,
         cpus=config.nextflow.threads,


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Rework nextflow logging and working directory structure.

### The Why
Logging in cellophane is being reworked to make debugging errors less cumbersome. This PR brings the nextflow module more in line with cellophane as a whole.

### The How
- Remove `nxf_launch`as a separate directory and work in `$TMPDIR` directly instead.
- Move the main nextflow log into the workidng directory and name it similar to other cellophane logs
- Rename the `nxf_work` directory similar to the log file to better show what job it belongs to

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
