### PR TITLE
fix: Ensure 'nxf_launch' exists

### DIFF
--- a/modules/nextflow/src/util.py
+++ b/modules/nextflow/src/util.py
@@ -38,6 +38,7 @@ def nextflow(
 
     _nxf_log.parent.mkdir(parents=True, exist_ok=True)
     _nxf_work.mkdir(parents=True, exist_ok=True)
+    _nxf_launch.mkdir(parents=True, exist_ok=True)
 
     result, uuid = executor.submit(
         str(_ROOT / "scripts" / "nextflow.sh"),


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Create `nxf_launch` before starting nextflow job

### The Why
The job script tries to `cd` to `nxf_launch` and crashes as it doesn't exist

### The How
Ensure the directory exists before running the job

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
