### PR TITLE
fix: Rework lexer to better support derived/parent queries

### DIFF
--- a/modules/slims_/__init__.py
+++ b/modules/slims_/__init__.py
@@ -7,7 +7,6 @@ from .src.util import (
     get_records,
     parse_criteria,
     resolve_criteria,
-    split_criteria,
     unnest_criteria,
     validate_criteria,
 )

--- a/modules/slims_/tests/criteria.yaml
+++ b/modules/slims_/tests/criteria.yaml
@@ -504,3 +504,66 @@ records:
   - !!python/object/apply:slims_.tests.RecordMock []
 exception: !!python/name:ValueError
 
+---
+id: has_derived_conjunction_outer
+criteria: cntn_id equals parent and has_derived cntn_a equals a and cntn_b equals b
+records:
+  - !!python/object/apply:slims_.tests.RecordMock
+    kwds:
+      cntn_id: {value: parent}
+      cntn_pk: {value: 1}
+      cntn_fk_originalContent: {value: 0}
+      cntn_b: {value: b}
+  - !!python/object/apply:slims_.tests.RecordMock
+    kwds:
+      cntn_id: {value: derived}
+      cntn_pk: {value: 2}
+      cntn_fk_originalContent: {value: 1}
+      cntn_a: {value: a}
+unnested:
+  operator: and
+  criteria:
+  - fieldName: cntn_id
+    operator: equals
+    value: parent
+  - operator: has_derived
+    value:
+      fieldName: cntn_a
+      operator: equals
+      value: a
+  - fieldName: cntn_b
+    operator: equals
+    value: b
+
+---
+id: has_derived_conjunction_inner
+criteria: cntn_id equals parent and has_derived (cntn_a equals a and cntn_b equals b)
+records:
+  - !!python/object/apply:slims_.tests.RecordMock
+    kwds:
+      cntn_id: {value: parent}
+      cntn_pk: {value: 1}
+      cntn_fk_originalContent: {value: 0}
+  - !!python/object/apply:slims_.tests.RecordMock
+    kwds:
+      cntn_id: {value: derived}
+      cntn_pk: {value: 2}
+      cntn_fk_originalContent: {value: 1}
+      cntn_a: {value: a}
+      cntn_b: {value: b}
+unnested:
+  operator: and
+  criteria:
+  - fieldName: cntn_id
+    operator: equals
+    value: parent
+  - operator: has_derived
+    value:
+      operator: and
+      criteria:
+      - fieldName: cntn_a
+        operator: equals
+        value: a
+      - fieldName: cntn_b
+        operator: equals
+        value: b


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Reworks the criteria lexer to provide better support for queries using 'has_parent' and 'has_derived' with parentheses.

### The Why
The lexer was very broken for this type of query, and would result in conjunctions at the wrong level.

### The How
Split the query into tokens, only preserving parentheses. Simplify the parser to use tokens rather than longer sub-queries.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
