### PR TITLE
fix: Add bioconda to spring extractor conda env

### DIFF
--- a/modules/unpack/src/extractors.py
+++ b/modules/unpack/src/extractors.py
@@ -121,7 +121,10 @@ class SpringExtractor(
     label="spring",
     script=Path(__file__).parent.parent / "scripts" / "spring.sh",
     suffixes=(".spring",),
-    conda_spec={"dependencies": ["spring >=1.1.1, <2.0.0"]},
+    conda_spec={
+        "channels": ["bioconda", "conda-forge"],
+        "dependencies": ["spring >=1.1.1, <2.0.0"]
+    },
 ):
     """Spring extractor."""
 


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Add bioconda channel to spring extractor environment

### The Why
The spring package cannot be installed without bioconda

### The How
Pass it in the conda_spec of executor.submit

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
