### PR TITLE
fix: Ensure backup keys are ordered

### DIFF
--- a/modules/hcp/src/mixins.py
+++ b/modules/hcp/src/mixins.py
@@ -9,10 +9,10 @@ from cellophane import Sample
 class HCPSample(Sample):
     """Sample with HCP backup."""
 
-    hcp_remote_keys: set[str] | None = field(
+    hcp_remote_keys: list[str] | None = field(
         default=None,
         kw_only=True,
-        converter=lambda value: None if value is None else {str(v) for v in value},
+        converter=lambda value: None if value is None else [str(v) for v in value],
         on_setattr=convert,
     )
 
@@ -20,7 +20,7 @@ class HCPSample(Sample):
     def _validate_hcp_remote_keys(
         self,
         attribute: Attribute,
-        value: set[str] | None,
+        value: list[str] | None,
     ) -> None:
         if value and len(value) != len(self.files):
             raise ValueError(
@@ -30,6 +30,7 @@ class HCPSample(Sample):
 
 
 @Sample.merge.register("hcp_remote_keys")
-def merge_hcp_remote_keys(this, that) -> set[str] | None:
+def merge_hcp_remote_keys(this, that) -> list[str] | None:
     """Merge HCP remote keys."""
-    return None if (this or that) is None else (this or set()) | (that or set())
+    # Use dict.fromkeys to preserve order while removing duplicates
+    return None if (this or that) is None else [*(dict.fromkeys(this or []) | dict.fromkeys(that or []))]

--- a/modules/hcp/tests/integration.yaml
+++ b/modules/hcp/tests/integration.yaml
@@ -91,8 +91,8 @@
       A: A
       B: B
   logs:
-    - sample.id='A' sample.hcp_remote_keys={'A'}
-    - sample.id='B' sample.hcp_remote_keys={'B'}
+    - sample.id='A' sample.hcp_remote_keys=['A']
+    - sample.id='B' sample.hcp_remote_keys=['B']
 
 - <<: *hcp_test
   id: hcp_length_missmatch
@@ -109,3 +109,94 @@
   logs:
     - "Unhandled exception: ValueError('Length mismatch between hcp_remote_keys and files: 2 != 1')"
   exception: SystemExit(1)
+
+- <<: *hcp_test
+  id: hcp_order
+  structure:
+    modules:
+      runner.py: |
+        from cellophane import runner, post_hook, pre_hook
+        @runner()
+        def a(samples, **_):
+            return samples
+
+        @runner()
+        def b(samples, **_):
+            return samples
+
+        @post_hook()
+        def check(samples, logger, **_):
+            for sample in samples:
+              logger.info(f"{sample.id=} {sample.hcp_remote_keys=}")
+
+    samples.yaml: |
+      - id: A
+        files:
+        - input/A_0
+        - input/A_1
+        - input/A_2
+        - input/A_3
+        - input/A_4
+        - input/A_5
+        - input/A_6
+        - input/A_7
+        - input/A_8
+        - input/A_9
+        hcp_remote_keys:
+        - A_0
+        - A_1
+        - A_2
+        - A_3
+        - A_4
+        - A_5
+        - A_6
+        - A_7
+        - A_8
+        - A_9
+      - id: B
+        files:
+        - input/B_0
+        - input/B_1
+        - input/B_2
+        - input/B_3
+        - input/B_4
+        - input/B_5
+        - input/B_6
+        - input/B_7
+        - input/B_8
+        - input/B_9
+        hcp_remote_keys:
+        - B_0
+        - B_1
+        - B_2
+        - B_3
+        - B_4
+        - B_5
+        - B_6
+        - B_7
+        - B_8
+        - B_9
+    input:
+      A_0: A
+      A_1: A
+      A_2: A
+      A_3: A
+      A_4: A
+      A_5: A
+      A_6: A
+      A_7: A
+      A_8: A
+      A_9: A
+      B_0: B
+      B_1: B
+      B_2: B
+      B_3: B
+      B_4: B
+      B_5: B
+      B_6: B
+      B_7: B
+      B_8: B
+      B_9: B
+  logs:
+    - sample.id='A' sample.hcp_remote_keys=['A_0', 'A_1', 'A_2', 'A_3', 'A_4', 'A_5', 'A_6', 'A_7', 'A_8', 'A_9']
+    - sample.id='B' sample.hcp_remote_keys=['B_0', 'B_1', 'B_2', 'B_3', 'B_4', 'B_5', 'B_6', 'B_7', 'B_8', 'B_9']

--- a/modules/s3/src/mixins.py
+++ b/modules/s3/src/mixins.py
@@ -9,10 +9,10 @@ from cellophane import Sample
 class S3Sample(Sample):
     """Sample with S3 backup."""
 
-    s3_remote_keys: set[str] | None = field(
+    s3_remote_keys: list[str] | None = field(
         default=None,
         kw_only=True,
-        converter=lambda value: None if value is None else {str(v) for v in value},
+        converter=lambda value: None if value is None else [str(v) for v in value],
         on_setattr=convert,
     )
 
@@ -32,7 +32,7 @@ class S3Sample(Sample):
     def _validate_s3_remote_keys(
         self,
         attribute: Attribute,
-        value: set[str] | None,
+        value: list[str] | None,
     ) -> None:
         if value and len(value) != len(self.files):
             raise ValueError(
@@ -42,6 +42,7 @@ class S3Sample(Sample):
 
 
 @Sample.merge.register("s3_remote_keys")
-def merge_s3_remote_keys(this, that) -> set[str] | None:
+def merge_s3_remote_keys(this, that) -> list[str] | None:
     """Merge S3 remote keys."""
-    return None if (this or that) is None else (this or set()) | (that or set())
+    # Use dict.fromkeys to preserve order while removing duplicates
+    return None if (this or that) is None else [*(dict.fromkeys(this or []) | dict.fromkeys(that or []))]

--- a/modules/s3/tests/integration.yaml
+++ b/modules/s3/tests/integration.yaml
@@ -105,8 +105,8 @@
       A: A
       B: B
   logs:
-    - sample.id='A' sample.s3_remote_keys={'A'}
-    - sample.id='B' sample.s3_remote_keys={'B'}
+    - sample.id='A' sample.s3_remote_keys=['A']
+    - sample.id='B' sample.s3_remote_keys=['B']
 
 - <<: *s3_test
   id: s3_length_missmatch
@@ -125,3 +125,94 @@
   logs:
     - "Unhandled exception: ValueError('Length mismatch between s3_remote_keys and files: 2 != 1')"
   exception: SystemExit(1)
+
+- <<: *s3_test
+  id: s3_order
+  structure:
+    modules:
+      runner.py: |
+        from cellophane import runner, post_hook, pre_hook
+        @runner()
+        def a(samples, **_):
+            return samples
+
+        @runner()
+        def b(samples, **_):
+            return samples
+
+        @post_hook()
+        def check(samples, logger, **_):
+            for sample in samples:
+              logger.info(f"{sample.id=} {sample.s3_remote_keys=}")
+
+    samples.yaml: |
+      - id: A
+        files:
+        - input/A_0
+        - input/A_1
+        - input/A_2
+        - input/A_3
+        - input/A_4
+        - input/A_5
+        - input/A_6
+        - input/A_7
+        - input/A_8
+        - input/A_9
+        s3_remote_keys:
+        - A_0
+        - A_1
+        - A_2
+        - A_3
+        - A_4
+        - A_5
+        - A_6
+        - A_7
+        - A_8
+        - A_9
+      - id: B
+        files:
+        - input/B_0
+        - input/B_1
+        - input/B_2
+        - input/B_3
+        - input/B_4
+        - input/B_5
+        - input/B_6
+        - input/B_7
+        - input/B_8
+        - input/B_9
+        s3_remote_keys:
+        - B_0
+        - B_1
+        - B_2
+        - B_3
+        - B_4
+        - B_5
+        - B_6
+        - B_7
+        - B_8
+        - B_9
+    input:
+      A_0: A
+      A_1: A
+      A_2: A
+      A_3: A
+      A_4: A
+      A_5: A
+      A_6: A
+      A_7: A
+      A_8: A
+      A_9: A
+      B_0: B
+      B_1: B
+      B_2: B
+      B_3: B
+      B_4: B
+      B_5: B
+      B_6: B
+      B_7: B
+      B_8: B
+      B_9: B
+  logs:
+    - sample.id='A' sample.s3_remote_keys=['A_0', 'A_1', 'A_2', 'A_3', 'A_4', 'A_5', 'A_6', 'A_7', 'A_8', 'A_9']
+    - sample.id='B' sample.s3_remote_keys=['B_0', 'B_1', 'B_2', 'B_3', 'B_4', 'B_5', 'B_6', 'B_7', 'B_8', 'B_9']


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Ensures backup keys remain in the order they were given. This change affects both the soon-to-be legacy HCP module and the new S3 module.

### The Why
R1 and R2 for a sample would get mixed up when they were fetched from backup.

### The How
- Update the merger functions to use `dict.fromkeys` as a makeshift ordered set.
- Make backup keys a `list` rather than a `set` as we no longer use sets internally for merging anyway.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
