### PR TITLE
fix: Ensure correct file insert order

### DIFF
--- a/modules/hcp/src/hooks.py
+++ b/modules/hcp/src/hooks.py
@@ -34,7 +34,6 @@ def hcp_fetch(
         use_dill=True,
     ) as pool:
         for sample in samples.without_files:
-            sample.files = []
             if sample.hcp_remote_keys is None:
                 logger.warning(f"No backup for {sample.id}")
                 continue
@@ -44,7 +43,7 @@ def hcp_fetch(
                 local_path = fastq_temp / Path(remote_key).name
 
                 if local_path.exists():
-                    sample.files.insert(f_idx, local_path)
+                    sample.files[f_idx] = local_path
                     logger.debug(f"Found {local_path.name} locally")
                     cleaner.register(local_path.resolve())
                     continue

--- a/modules/hcp/src/util.py
+++ b/modules/hcp/src/util.py
@@ -43,7 +43,7 @@ def callback(
 
     def inner(local_path: Path) -> None:
         logger.debug(f"Fetched {local_path.name} from hcp")
-        sample.files.insert(f_idx, local_path)
+        sample.files[f_idx] = local_path
         cleaner.register(local_path.resolve())
 
     return inner

--- a/modules/hcp/tests/integration.yaml
+++ b/modules/hcp/tests/integration.yaml
@@ -63,6 +63,7 @@
     modules:
       runner.py: |
         from cellophane import runner, post_hook, pre_hook
+
         @runner()
         def a(samples, **_):
             return samples
@@ -79,20 +80,21 @@
     samples.yaml: |
       - id: A
         files:
-        - input/A
+        - input/A_1
+        - input/A_2
         hcp_remote_keys:
-        - A
+        - A_0
+        - A_1
       - id: B
         files:
-        - input/B
+        - input/B_1
+        - input/B_2
         hcp_remote_keys:
-        - B
-    input:
-      A: A
-      B: B
+        - B_0
+        - B_1
   logs:
-    - sample.id='A' sample.hcp_remote_keys=['A']
-    - sample.id='B' sample.hcp_remote_keys=['B']
+    - sample.id='A' sample.hcp_remote_keys=['A_0', 'A_1']
+    - sample.id='B' sample.hcp_remote_keys=['B_0', 'B_1']
 
 - <<: *hcp_test
   id: hcp_length_missmatch
@@ -112,10 +114,22 @@
 
 - <<: *hcp_test
   id: hcp_order
+  args:
+    --samples_file: samples.yaml
+    --workdir: work
+    --hcp_credentials: "DUMMY"
+    --tag: "DUMMY"
   structure:
     modules:
       runner.py: |
         from cellophane import runner, post_hook, pre_hook
+
+        @pre_hook(after="all")
+        def ensure_files(samples, **_):
+            for sample in samples:
+                for f in sample.files:
+                    f.touch()
+
         @runner()
         def a(samples, **_):
             return samples
@@ -128,75 +142,17 @@
         def check(samples, logger, **_):
             for sample in samples:
               logger.info(f"{sample.id=} {sample.hcp_remote_keys=}")
+              logger.info(f"{sample.id=} files={[str(f) for f in sample.files]}")
 
     samples.yaml: |
       - id: A
-        files:
-        - input/A_0
-        - input/A_1
-        - input/A_2
-        - input/A_3
-        - input/A_4
-        - input/A_5
-        - input/A_6
-        - input/A_7
-        - input/A_8
-        - input/A_9
-        hcp_remote_keys:
-        - A_0
-        - A_1
-        - A_2
-        - A_3
-        - A_4
-        - A_5
-        - A_6
-        - A_7
-        - A_8
-        - A_9
+        files: [input/A_0, input/A_1, input/A_2, input/A_3, input/A_4, input/A_5, input/A_6, input/A_7, input/A_8, input/A_9]
+        hcp_remote_keys: [A_0, A_1, A_2, A_3, A_4, A_5, A_6, A_7, A_8, A_9]
       - id: B
-        files:
-        - input/B_0
-        - input/B_1
-        - input/B_2
-        - input/B_3
-        - input/B_4
-        - input/B_5
-        - input/B_6
-        - input/B_7
-        - input/B_8
-        - input/B_9
-        hcp_remote_keys:
-        - B_0
-        - B_1
-        - B_2
-        - B_3
-        - B_4
-        - B_5
-        - B_6
-        - B_7
-        - B_8
-        - B_9
-    input:
-      A_0: A
-      A_1: A
-      A_2: A
-      A_3: A
-      A_4: A
-      A_5: A
-      A_6: A
-      A_7: A
-      A_8: A
-      A_9: A
-      B_0: B
-      B_1: B
-      B_2: B
-      B_3: B
-      B_4: B
-      B_5: B
-      B_6: B
-      B_7: B
-      B_8: B
-      B_9: B
+        files: [input/B_0, input/B_1, input/B_2, input/B_3, input/B_4, input/B_5, input/B_6, input/B_7, input/B_8, input/B_9]
+        hcp_remote_keys: [B_0, B_1, B_2, B_3, B_4, B_5, B_6, B_7, B_8, B_9]
   logs:
     - sample.id='A' sample.hcp_remote_keys=['A_0', 'A_1', 'A_2', 'A_3', 'A_4', 'A_5', 'A_6', 'A_7', 'A_8', 'A_9']
+    - sample.id='A' files=['work/DUMMY/from_hcp/A_0', 'work/DUMMY/from_hcp/A_1', 'work/DUMMY/from_hcp/A_2', 'work/DUMMY/from_hcp/A_3', 'work/DUMMY/from_hcp/A_4', 'work/DUMMY/from_hcp/A_5', 'work/DUMMY/from_hcp/A_6', 'work/DUMMY/from_hcp/A_7', 'work/DUMMY/from_hcp/A_8', 'work/DUMMY/from_hcp/A_9']
     - sample.id='B' sample.hcp_remote_keys=['B_0', 'B_1', 'B_2', 'B_3', 'B_4', 'B_5', 'B_6', 'B_7', 'B_8', 'B_9']
+    - sample.id='B' files=['work/DUMMY/from_hcp/B_0', 'work/DUMMY/from_hcp/B_1', 'work/DUMMY/from_hcp/B_2', 'work/DUMMY/from_hcp/B_3', 'work/DUMMY/from_hcp/B_4', 'work/DUMMY/from_hcp/B_5', 'work/DUMMY/from_hcp/B_6', 'work/DUMMY/from_hcp/B_7', 'work/DUMMY/from_hcp/B_8', 'work/DUMMY/from_hcp/B_9']

--- a/modules/s3/src/hooks.py
+++ b/modules/s3/src/hooks.py
@@ -34,7 +34,6 @@ def s3_fetch(
         use_dill=True,
     ) as pool:
         for sample in samples.without_files:
-            sample.files = []
             if sample.s3_remote_keys is None:
                 logger.warning(f"No backup for {sample.id}")
                 continue
@@ -53,7 +52,7 @@ def s3_fetch(
                 local_path = fastq_temp / Path(remote_key).name
 
                 if local_path.exists():
-                    sample.files.insert(f_idx, local_path)
+                    sample.files[f_idx] = local_path
                     logger.debug(f"Found {local_path.name} locally")
                     cleaner.register(local_path.resolve())
                     continue

--- a/modules/s3/src/util.py
+++ b/modules/s3/src/util.py
@@ -74,7 +74,7 @@ def callback(
 
     def inner(local_path: Path) -> None:
         logger.debug(f"Fetched {local_path.name} from s3 bucket '{bucket}'")
-        sample.files.insert(f_idx, local_path)
+        sample.files[f_idx] = local_path
         cleaner.register(local_path.resolve())
 
     return inner

--- a/modules/s3/tests/integration.yaml
+++ b/modules/s3/tests/integration.yaml
@@ -23,6 +23,7 @@
     --samples_file: samples.yaml
     --workdir: work
     --s3_credentials: credentials.json
+    --tag: "DUMMY"
   logs:
     - Fetched BACKUP from s3
 
@@ -89,24 +90,30 @@
     samples.yaml: |
       - id: A
         files:
-        - input/A
+        - input/A_1
+        - input/A_2
         s3_remote_keys:
-        - A
+        - A_1
+        - A_2
         s3_bucket: test-bucket
         s3_endpoint: DUMMY
       - id: B
         files:
-        - input/B
+        - input/B_1
+        - input/B_2
         s3_remote_keys:
-        - B
+        - B_1
+        - B_2
         s3_bucket: test-bucket
         s3_endpoint: DUMMY
     input:
-      A: A
-      B: B
+      A_1: A
+      A_2: A
+      B_1: B
+      B_2: B
   logs:
-    - sample.id='A' sample.s3_remote_keys=['A']
-    - sample.id='B' sample.s3_remote_keys=['B']
+    - sample.id='A' sample.s3_remote_keys=['A_1', 'A_2']
+    - sample.id='B' sample.s3_remote_keys=['B_1', 'B_2']
 
 - <<: *s3_test
   id: s3_length_missmatch
@@ -132,6 +139,13 @@
     modules:
       runner.py: |
         from cellophane import runner, post_hook, pre_hook
+
+        @pre_hook(after="all")
+        def ensure_files(samples, **_):
+            for sample in samples:
+                for f in sample.files:
+                    f.touch()
+
         @runner()
         def a(samples, **_):
             return samples
@@ -144,75 +158,36 @@
         def check(samples, logger, **_):
             for sample in samples:
               logger.info(f"{sample.id=} {sample.s3_remote_keys=}")
-
+              logger.info(f"{sample.id=} files={[str(f) for f in sample.files]}")
     samples.yaml: |
       - id: A
-        files:
-        - input/A_0
-        - input/A_1
-        - input/A_2
-        - input/A_3
-        - input/A_4
-        - input/A_5
-        - input/A_6
-        - input/A_7
-        - input/A_8
-        - input/A_9
-        s3_remote_keys:
-        - A_0
-        - A_1
-        - A_2
-        - A_3
-        - A_4
-        - A_5
-        - A_6
-        - A_7
-        - A_8
-        - A_9
+        files: [
+          input/A_0, input/A_1, input/A_2,
+          input/A_3, input/A_4, input/A_5,
+          input/A_6, input/A_7, input/A_8,
+          input/A_9
+        ]
+        s3_remote_keys: [A_0, A_1, A_2, A_3, A_4, A_5, A_6, A_7, A_8, A_9]
+        s3_bucket: test-bucket
+        s3_endpoint: DUMMY
       - id: B
-        files:
-        - input/B_0
-        - input/B_1
-        - input/B_2
-        - input/B_3
-        - input/B_4
-        - input/B_5
-        - input/B_6
-        - input/B_7
-        - input/B_8
-        - input/B_9
-        s3_remote_keys:
-        - B_0
-        - B_1
-        - B_2
-        - B_3
-        - B_4
-        - B_5
-        - B_6
-        - B_7
-        - B_8
-        - B_9
-    input:
-      A_0: A
-      A_1: A
-      A_2: A
-      A_3: A
-      A_4: A
-      A_5: A
-      A_6: A
-      A_7: A
-      A_8: A
-      A_9: A
-      B_0: B
-      B_1: B
-      B_2: B
-      B_3: B
-      B_4: B
-      B_5: B
-      B_6: B
-      B_7: B
-      B_8: B
-      B_9: B
+        files: [
+          input/B_0, input/B_1, input/B_2,
+          input/B_3, input/B_4, input/B_5,
+          input/B_6, input/B_7, input/B_8,
+          input/B_9
+        ]
+        s3_remote_keys: [B_0, B_1, B_2, B_3, B_4, B_5, B_6, B_7, B_8, B_9]
+        s3_bucket: test-bucket
+        s3_endpoint: DUMMY
+    credentials.json: |
+      {
+        "endpoint": "DUMMY",
+        "aws_access_key_id": "DUMMY",
+        "aws_secret_access_key": "DUMMY"
+      }
   logs:
     - sample.id='A' sample.s3_remote_keys=['A_0', 'A_1', 'A_2', 'A_3', 'A_4', 'A_5', 'A_6', 'A_7', 'A_8', 'A_9']
+    - sample.id='A' files=['work/DUMMY/from_s3/A_0', 'work/DUMMY/from_s3/A_1', 'work/DUMMY/from_s3/A_2', 'work/DUMMY/from_s3/A_3', 'work/DUMMY/from_s3/A_4', 'work/DUMMY/from_s3/A_5', 'work/DUMMY/from_s3/A_6', 'work/DUMMY/from_s3/A_7', 'work/DUMMY/from_s3/A_8', 'work/DUMMY/from_s3/A_9']
     - sample.id='B' sample.s3_remote_keys=['B_0', 'B_1', 'B_2', 'B_3', 'B_4', 'B_5', 'B_6', 'B_7', 'B_8', 'B_9']
+    - sample.id='B' files=['work/DUMMY/from_s3/B_0', 'work/DUMMY/from_s3/B_1', 'work/DUMMY/from_s3/B_2', 'work/DUMMY/from_s3/B_3', 'work/DUMMY/from_s3/B_4', 'work/DUMMY/from_s3/B_5', 'work/DUMMY/from_s3/B_6', 'work/DUMMY/from_s3/B_7', 'work/DUMMY/from_s3/B_8', 'work/DUMMY/from_s3/B_9']

--- a/modules/unpack/tests/integration.yaml
+++ b/modules/unpack/tests/integration.yaml
@@ -6,12 +6,17 @@
   structure:
     modules:
       a.py: |
-        from cellophane import Executor
+        from cellophane import Executor, pre_hook
         from pathlib import Path
 
         class DummyExecutor(Executor, name="dummy"):
             def target(self, *args, env, **kwargs):
               Path(env["EXTRACTED_PATH"]).touch()
+
+        @pre_hook(after="all")
+        def check_outputs(samples, logger, **kwargs):
+            for sample in samples:
+                logger.info(f"{sample.id=} files={[str(f) for f in sample.files]}")
 
     samples.yaml: |
       - id: fasterq
@@ -23,9 +28,11 @@
     --workdir: work
     --samples_file: samples.yaml
     --executor_name: "dummy"
+    --tag: "fasterq"
   logs:
     - Extracting file.fasterq with petagene
     - Extracted file.fastq.gz
+    - sample.id='fasterq' files=['work/fasterq/unpack/file.fastq.gz']
 
 
 - id: unpack_spring
@@ -36,12 +43,17 @@
   structure:
     modules:
       a.py: |
-        from cellophane import Executor
+        from cellophane import Executor, pre_hook
         from pathlib import Path
 
         class DummyExecutor(Executor, name="dummy"):
             def target(self, *args, env, **kwargs):
               Path(env["EXTRACTED_PATH"]).touch()
+
+        @pre_hook(after="all")
+        def check_outputs(samples, logger, **kwargs):
+            for sample in samples:
+                logger.info(f"{sample.id=} files={[str(f) for f in sample.files]}")
 
     samples.yaml: |
       - id: spring
@@ -53,9 +65,11 @@
     --workdir: work
     --samples_file: samples.yaml
     --executor_name: "dummy"
+    --tag: "spring"
   logs:
     - Extracting file.spring with spring
     - Extracted file.fastq.gz
+    - sample.id='spring' files=['work/spring/unpack/file.fastq.gz']
 
 
 - id: unpack_spring_multi_a
@@ -66,7 +80,7 @@
   structure:
     modules:
       a.py: |
-        from cellophane import Executor
+        from cellophane import Executor, pre_hook
         from pathlib import Path
 
         class DummyExecutor(Executor, name="dummy"):
@@ -74,6 +88,12 @@
               base = env["EXTRACTED_PATH"].partition(".")[0]
               Path(base).with_suffix(".fastq.gz.1").touch()
               Path(base).with_suffix(".fastq.gz.2").touch()
+
+        @pre_hook(after="all")
+        def check_outputs(samples, logger, **kwargs):
+            for sample in samples:
+                logger.info(f"{sample.id=} files={[str(f) for f in sample.files]}")
+
 
     samples.yaml: |
       - id: spring
@@ -85,10 +105,12 @@
     --workdir: work
     --samples_file: samples.yaml
     --executor_name: "dummy"
+    --tag: "spring"
   logs:
     - Extracting file.spring with spring
     - Extracted file.1.fastq.gz
     - Extracted file.2.fastq.gz
+    - sample.id='spring' files=['work/spring/unpack/file.1.fastq.gz', 'work/spring/unpack/file.2.fastq.gz']
 
 
 - id: unpack_spring_multi_b
@@ -99,7 +121,7 @@
   structure:
     modules:
       a.py: |
-        from cellophane import Executor
+        from cellophane import Executor, pre_hook
         from pathlib import Path
 
         class DummyExecutor(Executor, name="dummy"):
@@ -107,6 +129,11 @@
               base = env["EXTRACTED_PATH"].partition(".")[0]
               Path(base).with_suffix(".1.fastq.gz").touch()
               Path(base).with_suffix(".2.fastq.gz").touch()
+
+        @pre_hook(after="all")
+        def check_outputs(samples, logger, **kwargs):
+            for sample in samples:
+                logger.info(f"{sample.id=} files={[str(f) for f in sample.files]}")
 
     samples.yaml: |
       - id: spring
@@ -118,10 +145,12 @@
     --workdir: work
     --samples_file: samples.yaml
     --executor_name: "dummy"
+    --tag: "spring"
   logs:
     - Extracting file.spring with spring
     - Extracted file.1.fastq.gz
     - Extracted file.2.fastq.gz
+    - sample.id='spring' files=['work/spring/unpack/file.1.fastq.gz', 'work/spring/unpack/file.2.fastq.gz']
 
 
 - id: unpack_exception


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Ensure files are added in the correct order in the HCP, S3 and unpack modules. Fixes a bunch of really dumb bugs that we probably never actually ran into.

### The Why
- The HCP and S3 modules had a bug where files would sometimes be added out of order if there were more than 2 per sample.
- The unpack module would always add samples in reverse order if more than one `.fastq` file was unpacked from one `.spring` file.

### The How
- Avoid using `.insert` as it doesn't really work if there are more than 2 files.
- Get the current index of the compressed file in `sample.files` rather than the original index. The original index may be out of sync if another unpack operation has added multiple files where there used to be only one.
- Reverse the order when inserting multiple files in place of the compressed path. Otherwise, the inserted paths will always be in the reverse order.
- Use a lock in the extract callback of the unpack module to ensure only a single thread is working on a sample at once.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
