### PR TITLE
refactor: Use instance variable for tracking grid engine jobs

### DIFF
--- a/modules/grid_engine/tests/integration.yaml
+++ b/modules/grid_engine/tests/integration.yaml
@@ -20,7 +20,7 @@
     --workdir: work
     --executor_name: grid_engine
   logs:
-    - Submitted job 'grid_engine' to Grid Engine (UUID=deadbeef JID=DUMMY)
+    - Submitted job 'grid_engine_job' to Grid Engine (UUID=deadbeef JID=DUMMY)
 
 - id: grid_engine_exception
   external:
@@ -42,7 +42,7 @@
     --workdir: work
     --executor_name: grid_engine
   logs:
-    - "Command failed with exit code: 1"
+    - "Non-zero exit code (1) for grid_engine job 'grid_engine_job'"
 
 - id: grid_engine_terminate
   external:
@@ -70,4 +70,4 @@
     --workdir: work
     --executor_name: grid_engine
   logs:
-    - "Terminated Grid Engine job 'grid_engine' (UUID=deadbeef JID=DUMMY)"
+    - "Terminated Grid Engine job 'grid_engine_job' (UUID=deadbeef JID=DUMMY)"


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Use and instance variable to track grid engine jobs for the current process, rather than relying on a global dict (_GE_JOBS).

### The Why
A similar change was added in cellophane 1.2.0 for the base executor. Further, the internal `Executor.uuid` variable was removed as it was no longer needed, so we cannot use that to identify an executor instance. 

### The How
- Add a _ge_jobs dict to the `GridEngineExecutor` class.
- Remove all references the `_GE_JOBS` global variable and the `ge_jobs` property on the `GridEngineExecutor` class.
- Add a `__getstate__` override to clear `self._ge_jobs` when an `GridEngineExecutor` instance is serialized.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure
NEEDS TO BE TESTED ON A REAL GRID ENGINE CLUSTER.

Included tests mock out submission of jobs to grid engine, so this needs to be verified on an actual cluster.

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
