### PR TITLE
chore: Update error log messages to use ValueError exceptions

### DIFF
--- a/modules/slims_/tests/integration.yaml
+++ b/modules/slims_/tests/integration.yaml
@@ -603,7 +603,7 @@
     --workdir: work
     --samples_file: samples.yaml
   logs:
-    - "ValueError: Expected 'NoneType' or 'Record' for 'record', got 'INVALID'"
+    - ValueError("Expected 'NoneType' or 'Record' for 'record', got 'INVALID'")
 
 - id: slims_derive_no_record
   external:
@@ -699,7 +699,7 @@
     --workdir: work
     --samples_file: samples.yaml
   logs:
-    - "ValueError: Expected 'dict[str, tuple[Record|None, dict]]' for '_derived', got INVALID"
+    - ValueError("Expected 'dict[str, tuple[Record|None, dict]]' for '_derived', got INVALID")
 
 - id: from_record_map_override
   external:


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Update tests to reflect logging syntax changes for exceptions in cellophane 1.2.0.

### The Why
Tests were failing because the log messages for exceptions changed.

### The How
Replace old messages with the new equivalent ones in tests.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
