### PR TITLE
Explicit check r1 r2

### DIFF
--- a/modules/nextflow/src/mixins.py
+++ b/modules/nextflow/src/mixins.py
@@ -36,8 +36,12 @@ def split_r1_r2(files, *, logger: LoggerAdapter | None = None, sample_id = None)
     """
     Strictly split a 2-file FASTQ pair into (R1, R2).
     """
-    if len(files) != 2:
-        raise ValueError(f"Expected exactly 2 FASTQ files for sample {sample_id!r}, got {len(files)}")
+    if len(files) == 1:
+        if logger:
+            logger.info(f"Only one FASTQ file found for sample {sample_id!r}, assuming single-end data.")
+        return str(files[0]), None
+    elif len(files) != 2:
+        raise ValueError(f"Expected either 1 (single-end) or 2 (paired-end) FASTQ files for sample {sample_id!r}, got {len(files)}")
 
     r1: str | None = None
     r2: str | None = None

--- a/modules/nextflow/src/mixins.py
+++ b/modules/nextflow/src/mixins.py
@@ -34,7 +34,10 @@ def _infer_read(path: str | Path) -> tuple[int | None, str]:
 
 def split_r1_r2(files, *, logger: LoggerAdapter | None = None, sample_id = None):
     """
-    Strictly split a 2-file FASTQ pair into (R1, R2).
+    Split a list of FASTQ files into (R1, R2).
+
+    Handles both single-end (returns (R1, None)) and paired-end (returns (R1, R2)) data.
+    Raises ValueError for unexpected file counts or ambiguous classification.
     """
     if len(files) == 1:
         if logger:

--- a/modules/nextflow/src/mixins.py
+++ b/modules/nextflow/src/mixins.py
@@ -15,21 +15,20 @@ def _infer_read(path: str | Path) -> tuple[int | None, str]:
     Infer read number (1 or 2) from filename tokens.
     Returns (read, how). If read is None, 'how' explains why.
     """
-    name = Path(path).name
+    name = Path(path).name  # Extract the filename only
 
-    for pat, how in ((_EXPLICIT, "explicit R1/R2 token"), (_NUMERIC, "numeric 1/2 token")):
-        last: int | None = None
+    # Try first explicit R1/R2 tokens, then bare 1/2 tokens.
+    for pattern, how in ((_EXPLICIT, "explicit R1/R2 token"), (_NUMERIC, "numeric 1/2 token")):
         seen: set[int] = set()
 
-        for m in pat.finditer(name):
-            val = int(m.group(1))
-            seen.add(val)
-            last = val
+        for match in pattern.finditer(name):
+            val = int(match.group(1))  # Extract the read number (1 or 2)
+            seen.add(val)  # within the set, multiple of the same value is fine
 
-        if last is not None:
-            if len(seen) > 1:
+        if seen:
+            if len(seen) > 1:  # E.g. both R1 and R2 found within one filename
                 return None, f"ambiguous: found both {sorted(seen)} via {how}"
-            return last, how
+            return next(iter(seen)), how
 
     return None, "no R1/R2 marker found"
 

--- a/modules/nextflow/src/mixins.py
+++ b/modules/nextflow/src/mixins.py
@@ -29,6 +29,7 @@ def _infer_read(path: str | Path) -> tuple[int | None, str]:
             if len(seen) > 1:  # E.g. both R1 and R2 found within one filename
                 return None, f"ambiguous: found both {sorted(seen)} via {how}"
             return next(iter(seen)), how
+
     return None, "no R1/R2 marker found"
 
 def split_r1_r2(files, *, logger: LoggerAdapter | None = None, sample_id = None):

--- a/modules/nextflow/src/mixins.py
+++ b/modules/nextflow/src/mixins.py
@@ -29,7 +29,6 @@ def _infer_read(path: str | Path) -> tuple[int | None, str]:
             if len(seen) > 1:  # E.g. both R1 and R2 found within one filename
                 return None, f"ambiguous: found both {sorted(seen)} via {how}"
             return next(iter(seen)), how
-
     return None, "no R1/R2 marker found"
 
 def split_r1_r2(files, *, logger: LoggerAdapter | None = None, sample_id = None):


### PR DESCRIPTION

### The What

Explicitly check the r1/r2 values for paired-end fastq files

### The Why

We would like to ensure the right path is submitted as the right paired-end fastq file in nextflow:
- To avoid wrong strandedness and unassigned reads in rnaseq
- Especially common to go wrong when the fastqs were downloaded from hcp (via slims)
- Even if someone builds a manual samples.yaml wrong since it is not clear that the files argument is supposed to be sorted R1,R2

### The How

- Use split_r1_r2() to return r1 and r2, with explicit logs why it might not have worked
- Notify the user when running with one fastq that single-end is used.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [X] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

### Tests

- Tested with a variety of manual samples.yaml files
- Tested with download from hcp

Also added to qd-rna here: https://github.com/ClinicalGenomicsGBG/qd_rna/pull/10