### PR TITLE
Dont overwrite slims

### DIFF
--- a/modules/hcp/src/hooks.py
+++ b/modules/hcp/src/hooks.py
@@ -19,14 +19,17 @@ def hcp_fetch(
     **_,
 ) -> Samples:
     """Fetch files from HCP."""
-    for sample in samples.with_files:
-        logger.debug(f"Found all files for {sample.id} locally")
-
     if not config.hcp.get("credentials"):
         logger.warning("HCP not configured")
         return samples
 
+    for sample in samples:
+        logger.debug(f"Files for sample {sample.id} (run={getattr(sample,'run',None)}): {sample.files}")
+        logger.debug(f"Files present on cluster: {[Path(f).exists() for f in sample.files]}")
+
     if samples.without_files:
+        for sample in samples.without_files:
+            logger.info(f"Fetching files for {sample.id} (run={getattr(sample,'run',None)}) from HCP: {sample.hcp_remote_keys}")
         logger.info(f"fetching {len(samples.without_files)} samples from HCP")
 
     with WorkerPool(

--- a/modules/hcp/src/hooks.py
+++ b/modules/hcp/src/hooks.py
@@ -24,12 +24,12 @@ def hcp_fetch(
         return samples
 
     for sample in samples:
-        logger.debug(f"Files for sample {sample.id} (run={getattr(sample,'run',None)}): {sample.files}")
+        logger.debug(f"Files for sample {sample.id} (UUID={sample.uuid}): {sample.files}")
         logger.debug(f"Files present on cluster: {[Path(f).exists() for f in sample.files]}")
 
     if samples.without_files:
         for sample in samples.without_files:
-            logger.info(f"Fetching files for {sample.id} (run={getattr(sample,'run',None)}) from HCP: {sample.hcp_remote_keys}")
+            logger.info(f"Fetching files for {sample.id} (UUID={sample.uuid}) from HCP: {sample.hcp_remote_keys}")
         logger.info(f"fetching {len(samples.without_files)} samples from HCP")
 
     with WorkerPool(
@@ -39,7 +39,7 @@ def hcp_fetch(
         for sample in samples.without_files:
             sample.files = []
             if sample.hcp_remote_keys is None:
-                logger.warning(f"No backup for {sample.id}")
+                logger.warning(f"No backup for {sample.uuid}")
                 continue
 
             fastq_temp = (workdir / "from_hcp")

--- a/modules/slims_/src/hooks.py
+++ b/modules/slims_/src/hooks.py
@@ -32,7 +32,7 @@ def _augment_sample(
             matching_record = record
 
     if matching_record is None:
-        warn(f"No records match sample '{sample.id}'")
+        warn(f"No records match sample '{sample.id}' with run={getattr(sample,'run',None)}")
         return
 
     sample.map_from_record(matching_record, _map)


### PR DESCRIPTION
### The What

Make sure if fields are preexisting (e.g. file paths, number of reads) not to overwrite when augmenting from slims

### The Why

When a manual run is started with user-provided paths, we do not want the slims module to overwrite these paths with the paths from slims

### The How

- Before writing to a field, check with _missing() if the field is missing
- I also increased verbosity for the logs to distinguish between samples with the same sample.id

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [X] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

### Tests

- Tested with manual runs containing/missing paths such as reads/files