### PR TITLE
Add timestamp to end_email

### DIFF
--- a/modules/mail/src/hooks.py
+++ b/modules/mail/src/hooks.py
@@ -1,8 +1,8 @@
 from logging import LoggerAdapter
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Optional
 
-from cellophane import Config, Samples, post_hook, pre_hook
+from cellophane import Config, Samples, Timestamp, post_hook, pre_hook
 
 from .util import render_mail, resolve_attachments, send_mail
 
@@ -13,6 +13,7 @@ def _mail_hook(
     config: Config,
     workdir: Path,
     when: Literal["start", "end"],
+    timestamp: Optional[Timestamp] = None,
     **_,
 ):
     if not samples:
@@ -29,6 +30,7 @@ def _mail_hook(
         body=config.mail[when].body,
         samples=samples,
         config=config,
+        timestamp=timestamp,
     )
 
     attachments = resolve_attachments(
@@ -101,6 +103,7 @@ def end_mail(
     logger: LoggerAdapter,
     config: Config,
     workdir: Path,
+    timestamp: Timestamp,
     **_,
 ):
     """Send a mail at the end of the analysis"""
@@ -110,4 +113,5 @@ def end_mail(
         config=config,
         workdir=workdir,
         when="end",
+        timestamp=timestamp,
     )


### PR DESCRIPTION
### The What

Add timestamp to email

### The Why

To be able to link to the correct result directory we need the timestamp

### The How

- Use `timestamp` in end_mail()
- Allow input of `timestamp` in _mail_hook()
- The keyword argument is used in resolve_mail and can be used in the jinja2 email template
  - for example: `{%- set results_node = id_ + '_' + group.0.last_run + '_' + (timestamp|string) -%}`

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [X] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

