### PR TITLE
tests: Ensure tests work with new exception logging style

### DIFF
--- a/modules/slims_/tests/integration.yaml
+++ b/modules/slims_/tests/integration.yaml
@@ -603,7 +603,7 @@
     --workdir: work
     --samples_file: samples.yaml
   logs:
-    - "ValueError: Expected 'NoneType' or 'Record' for 'record', got 'INVALID'"
+    - "Unhandled exception in runner 'a': ValueError(\"Expected 'NoneType' or 'Record' for 'record', got 'INVALID'\")"
 
 - id: slims_derive_no_record
   external:
@@ -699,7 +699,7 @@
     --workdir: work
     --samples_file: samples.yaml
   logs:
-    - "ValueError: Expected 'dict[str, tuple[Record|None, dict]]' for '_derived', got INVALID"
+    - "Unhandled exception in runner 'a': ValueError(\"Expected 'dict[str, tuple[Record|None, dict]]' for '_derived', got INVALID\")"
 
 - id: from_record_map_override
   external:


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
Fix tests to work with new exception logging in latest cellophane

### The Why
Test would fail because log formatting is different

### The How
Match the new formatting in tests

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
