### PR TITLE
feat: Add post-hook for S3 upload

### DIFF
--- a/modules/s3/__init__.py
+++ b/modules/s3/__init__.py
@@ -1,7 +1,7 @@
 """S3 module for cellphane."""
 
-from .src.hooks import s3_fetch
+from .src.hooks import s3_fetch, s3_upload_results
 from .src.mixins import S3Sample
 from .src.util import fetch
 
-__all__ = ["S3Sample", "fetch", "s3_fetch"]
+__all__ = ["S3Sample", "fetch", "s3_fetch", "s3_upload_results"]

--- a/modules/s3/schema.yaml
+++ b/modules/s3/schema.yaml
@@ -12,5 +12,28 @@ properties:
         type: integer
         description: Number of parallel S3 connections
         default: 4
+      upload:
+        type: object
+        oneOf:
+          - properties:
+              enable:
+                const: false
+          - required:
+            - path
+            - endpoint
+        properties:
+          enable:
+            type: boolean
+            description: Whether to enable S3 upload
+            default: false
+          path:
+            type: string
+            description: S3 path to upload results to in the the form s3://bucket/path
+            pattern: "^s3://[^/]+/.*$"
+          endpoint:
+            type: string
+            description: S3 endpoint URL (e.g. https://s3.amazonaws.com)
+            pattern: "^https?://.+$"
     required:
       - credentials
+      - upload

--- a/modules/s3/src/hooks.py
+++ b/modules/s3/src/hooks.py
@@ -2,11 +2,20 @@
 
 from logging import LoggerAdapter
 from pathlib import Path
+from urllib.parse import urlparse
 
-from cellophane import Cleaner, Config, Samples, pre_hook
+from cellophane import Cleaner, Config, Samples, pre_hook, post_hook
 from mpire import WorkerPool
 
-from .util import callback, error_callback, fetch, get_endpoint_credentials
+from .util import (
+    callback,
+    error_callback,
+    fetch,
+    get_endpoint_credentials,
+    upload,
+    upload_callback,
+    upload_error_callback,
+)
 
 
 @pre_hook(after=["slims_fetch"])
@@ -83,3 +92,78 @@ def s3_fetch(
         pool.join()
 
     return samples
+
+
+@post_hook(label="S3 Upload", condition="complete")
+def s3_upload_results(
+    samples: Samples,
+    config: Config,
+    logger: LoggerAdapter,
+    **_,
+) -> None:
+    """Upload output files to S3."""
+
+    if not config.s3.upload.get("enable"):
+        logger.info("S3 upload is disabled, skipping")
+        return
+    if not config.s3.get("credentials"):
+        logger.warning("Missing credentials for S3 upload, skipping")
+        return
+    if not samples.output:
+        logger.warning("No output to upload to S3, skipping")
+        return
+
+    endpoint = config.s3.upload.get("endpoint")
+    if not (credentials := get_endpoint_credentials(
+        config.s3.get("credentials"),
+        endpoint,
+    )):
+        logger.warning(f"No credentials for S3 endpoint '{endpoint}', skipping")
+        return
+
+    upload_path = config.s3.upload.get("path")
+    parsed = urlparse(upload_path)
+    upload_bucket = parsed.netloc
+    # AWS keys do not start with a slash, but urlparse includes the leading slash in the path, so we need to remove it
+    upload_prefix = parsed.path.lstrip("/")
+
+
+    logger.info(f"Uploading output to {upload_path}")
+
+    with WorkerPool(
+        n_jobs=config.s3.parallel,
+        use_dill=True,
+    ) as pool:
+        for output in samples.output:
+            if not output.src.exists():
+                logger.warning(f"{output.src} does not exist")
+                continue
+
+            # Preserve directory structure of results in S3
+            # output.dst is already prefixed with resultdir
+            relative_dst = output.dst.relative_to(config.get("resultdir"))
+            # Making sure to avoid double slashes
+            remote_key = f"{upload_prefix.rstrip('/')}/{relative_dst}"
+            pool.apply_async(
+                upload,
+                kwargs={
+                    "credentials": credentials,
+                    "local_path": output.src,
+                    "remote_key": remote_key,
+                    "bucket": upload_bucket,
+                },
+                callback=upload_callback(
+                    logger=logger,
+                    bucket=upload_bucket,
+                    remote_key=remote_key,
+                ),
+                error_callback=upload_error_callback(
+                    logger=logger,
+                    bucket=upload_bucket,
+                    remote_key=remote_key,
+                ),
+            )
+
+        pool.join()
+
+    logger.info("Finished uploading output to S3")

--- a/modules/s3/src/util.py
+++ b/modules/s3/src/util.py
@@ -92,3 +92,54 @@ def error_callback(
         sample.fail(f"Failed to fetch backup from s3 bucket '{bucket}'")
 
     return inner
+
+
+def upload(
+    *,
+    credentials: dict,
+    local_path: Path,
+    remote_key: str,
+    bucket: str,
+) -> Path:
+    """Uploads a file to S3."""
+    sys.stdout = open("/dev/null", "w", encoding="utf-8")
+    sys.stderr = open("/dev/null", "w", encoding="utf-8")
+    disable_warnings(InsecureRequestWarning)
+
+    _session = _get_s3_session(credentials=credentials)
+    _bucket = _session.Bucket(bucket)
+    _bucket.upload_file(
+        Filename=str(local_path),
+        Key=remote_key,
+        ExtraArgs={"ChecksumAlgorithm": "SHA256"}
+    )
+
+    return local_path
+
+
+def upload_callback(
+    logger: LoggerAdapter,
+    bucket: str,
+    remote_key: str,
+) -> Callable[[Path], None]:
+    """Callback for uploading files to S3."""
+
+    def inner(local_path: Path) -> None:
+        logger.debug(f"Uploaded {local_path.name} to s3://{bucket}/{remote_key}")
+
+    return inner
+
+
+def upload_error_callback(
+    logger: LoggerAdapter,
+    bucket: str,
+    remote_key: str,
+) -> Callable[[Exception], None]:
+    """Error callback for uploading files to S3."""
+
+    def inner(exception: Exception) -> None:
+        logger.error(
+            f"Failed to upload {remote_key} to s3 bucket '{bucket}' ({exception})"
+        )
+
+    return inner

--- a/modules/s3/tests/integration.yaml
+++ b/modules/s3/tests/integration.yaml
@@ -191,3 +191,87 @@
     - sample.id='A' files=['work/DUMMY/from_s3/A_0', 'work/DUMMY/from_s3/A_1', 'work/DUMMY/from_s3/A_2', 'work/DUMMY/from_s3/A_3', 'work/DUMMY/from_s3/A_4', 'work/DUMMY/from_s3/A_5', 'work/DUMMY/from_s3/A_6', 'work/DUMMY/from_s3/A_7', 'work/DUMMY/from_s3/A_8', 'work/DUMMY/from_s3/A_9']
     - sample.id='B' sample.s3_remote_keys=['B_0', 'B_1', 'B_2', 'B_3', 'B_4', 'B_5', 'B_6', 'B_7', 'B_8', 'B_9']
     - sample.id='B' files=['work/DUMMY/from_s3/B_0', 'work/DUMMY/from_s3/B_1', 'work/DUMMY/from_s3/B_2', 'work/DUMMY/from_s3/B_3', 'work/DUMMY/from_s3/B_4', 'work/DUMMY/from_s3/B_5', 'work/DUMMY/from_s3/B_6', 'work/DUMMY/from_s3/B_7', 'work/DUMMY/from_s3/B_8', 'work/DUMMY/from_s3/B_9']
+- &s3_upload_test
+  <<: *s3_test
+  id: s3_upload_success
+  args:
+    --workdir: work
+    --resultdir: output
+    --samples_file : samples.yaml
+    --s3_credentials: credentials.json
+    --s3_upload_enable: ~
+    --s3_upload_path: s3://test-bucket/uploaded
+    --s3_upload_endpoint: https://DUMMY
+    --tag: "DUMMY"
+  structure:
+    credentials.json: |
+      {
+        "endpoint": "https://DUMMY",
+        "aws_access_key_id": "DUMMY",
+        "aws_secret_access_key": "DUMMY"
+      }
+    samples.yaml: |
+      - id: TEST
+        files:
+        - input/TEST
+    modules:
+      runner.py: |
+        from cellophane import runner, post_hook, pre_hook, output
+
+        @runner()
+        @output("test.txt", dst_dir="output", dst_name="sample_test.txt")
+        def a(samples, workdir, **_):
+            (workdir / "test.txt").touch()
+    input:
+      TEST: TEST
+  logs:
+    - Uploading output to s3://test-bucket/uploaded
+    - Uploaded test.txt to s3://test-bucket/uploaded/output/sample_test.txt
+    - Finished uploading output to S3
+
+- <<: *s3_upload_test
+  id: s3_upload_skipped_disabled
+  args:
+    --workdir: work
+    --resultdir: output
+    --samples_file : samples.yaml
+  logs:
+    - S3 upload is disabled, skipping
+
+- <<: *s3_upload_test
+  id: s3_upload_wrong_credentials
+  args:
+    --workdir: work
+    --resultdir: output
+    --samples_file : samples.yaml
+    --s3_credentials: credentials.json
+    --s3_upload_enable: ~
+    --s3_upload_path: s3://test-bucket/uploaded
+    --s3_upload_endpoint: https://WRONG_ENDPOINT
+  logs:
+    - No credentials for S3 endpoint 'https://WRONG_ENDPOINT'
+
+- <<: *s3_upload_test
+  id: s3_upload_no_output
+  structure:
+    samples.yaml: |
+      - id: TEST
+        files:
+        - input/TEST
+    credentials.json: |
+      {
+        "endpoint": "https://DUMMY",
+        "aws_access_key_id": "DUMMY",
+        "aws_secret_access_key": "DUMMY"
+      }
+    modules:
+      runner.py: |
+        from cellophane import runner
+
+        @runner()
+        def a(samples, **_):
+            pass
+    input:
+      TEST: TEST
+  logs:
+    - No output to upload to S3


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What

* Added post hook for upload of runner outputs to S3.

### The Why

* Requested by cancer group to speed up availability on CMG portal

### The How

* Heaviliy plagiarized from the rsync post-hook and the existing S3 pre-hook.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat