### PR TITLE
fix: Recurse into output directories

### DIFF
--- a/modules/s3/src/hooks.py
+++ b/modules/s3/src/hooks.py
@@ -1,10 +1,11 @@
 """Hooks for fetching files from S3 bucket."""
 
+from collections import deque
 from logging import LoggerAdapter
 from pathlib import Path
 from urllib.parse import urlparse
 
-from cellophane import Cleaner, Config, Samples, pre_hook, post_hook
+from cellophane import Cleaner, Config, Samples, pre_hook, post_hook, Output
 from mpire import WorkerPool
 
 from .util import (
@@ -134,9 +135,25 @@ def s3_upload_results(
         n_jobs=config.s3.parallel,
         use_dill=True,
     ) as pool:
-        for output in samples.output:
+        upload_stack = deque(samples.output)
+        while len(upload_stack) > 0:
+            output = upload_stack.pop()
             if not output.src.exists():
                 logger.warning(f"{output.src} does not exist")
+                continue
+
+            if output.src.is_dir():
+                # If the output is a directory, put all files in the directory on the upload stack, preserving the directory structure in S3
+                for file in output.src.rglob("*"):
+                    if file.is_file():
+                        upload_stack.append(
+                            Output(
+                                src=file,
+                                dst=output.dst / file.relative_to(output.src),
+                                checkpoint=output.checkpoint,
+                                optional=output.optional
+                            )
+                        )
                 continue
 
             # Preserve directory structure of results in S3

--- a/modules/s3/src/hooks.py
+++ b/modules/s3/src/hooks.py
@@ -129,8 +129,12 @@ def s3_upload_results(
     # AWS keys do not start with a slash, but urlparse includes the leading slash in the path, so we need to remove it
     upload_prefix = parsed.path.lstrip("/")
 
-
     logger.info(f"Uploading output to {upload_path}")
+
+    for output in samples.output:
+        if not output.src.exists():
+            logger.warning(f"Output file {output.src} does not exist, skipping upload")
+            # Will be skipped implicitly by the upload loop, but we log it here for better visibility
 
     with WorkerPool(
         n_jobs=config.s3.parallel,

--- a/modules/s3/src/hooks.py
+++ b/modules/s3/src/hooks.py
@@ -13,6 +13,7 @@ from .util import (
     error_callback,
     fetch,
     get_endpoint_credentials,
+    recurse_outputs,
     upload,
     upload_callback,
     upload_error_callback,
@@ -135,27 +136,8 @@ def s3_upload_results(
         n_jobs=config.s3.parallel,
         use_dill=True,
     ) as pool:
-        upload_stack = deque(samples.output)
-        while len(upload_stack) > 0:
-            output = upload_stack.pop()
-            if not output.src.exists():
-                logger.warning(f"{output.src} does not exist")
-                continue
 
-            if output.src.is_dir():
-                # If the output is a directory, put all files in the directory on the upload stack, preserving the directory structure in S3
-                for file in output.src.rglob("*"):
-                    if file.is_file():
-                        upload_stack.append(
-                            Output(
-                                src=file,
-                                dst=output.dst / file.relative_to(output.src),
-                                checkpoint=output.checkpoint,
-                                optional=output.optional
-                            )
-                        )
-                continue
-
+        for output in recurse_outputs(samples.output):
             # Preserve directory structure of results in S3
             # output.dst is already prefixed with resultdir
             relative_dst = output.dst.relative_to(config.get("resultdir"))

--- a/modules/s3/src/util.py
+++ b/modules/s3/src/util.py
@@ -5,10 +5,11 @@ import sys
 from logging import LoggerAdapter
 from pathlib import Path
 from typing import Callable
+from collections.abc import Generator, Iterable
 
 import boto3
 from botocore.client import Config as BotocoreClientConfig
-from cellophane import Cleaner, Sample
+from cellophane import Cleaner, Sample, Output
 from mypy_boto3_s3.service_resource import S3ServiceResource
 from urllib3 import disable_warnings
 from urllib3.exceptions import InsecureRequestWarning
@@ -34,6 +35,7 @@ def _get_s3_session(
         ),
     )
 
+
 def get_endpoint_credentials(
     credential_paths: list[Path],
     endpoint: str,
@@ -43,6 +45,7 @@ def get_endpoint_credentials(
         if credentials.get("endpoint") == endpoint:
             return credentials
     return None
+
 
 def fetch(
     *,
@@ -111,7 +114,7 @@ def upload(
     _bucket.upload_file(
         Filename=str(local_path),
         Key=remote_key,
-        ExtraArgs={"ChecksumAlgorithm": "SHA256"}
+        ExtraArgs={"ChecksumAlgorithm": "SHA256"},
     )
 
     return local_path
@@ -143,3 +146,32 @@ def upload_error_callback(
         )
 
     return inner
+
+
+def recurse_outputs(outputs: Iterable[Output]) -> Generator[Output, None, None]:
+    """Search recursively for output files in the given paths.
+
+    Arguments
+    ---------
+    outputs: Iterable[Output]
+        An iterable of Output objects to search through.
+
+    Returns
+    -------
+    Generator[Output, None, None]
+        A generator of Output objects for each file found in the given paths.
+    """
+    for output in outputs:
+        if output.src.is_file():
+            yield output
+        elif output.src.is_dir():
+            yield from (
+                Output(
+                    src=file,
+                    dst=output.dst / file.relative_to(output.src),
+                    checkpoint=output.checkpoint,
+                    optional=output.optional,
+                )
+                for file in output.src.rglob("*")
+                if file.is_file()
+            )

--- a/modules/s3/src/util.py
+++ b/modules/s3/src/util.py
@@ -160,6 +160,7 @@ def recurse_outputs(outputs: Iterable[Output]) -> Generator[Output, None, None]:
     -------
     Generator[Output, None, None]
         A generator of Output objects for each file found in the given paths.
+        Only yields existing paths, even if argument points to missing files or directories.
     """
     for output in outputs:
         if output.src.is_file():

--- a/modules/s3/tests/integration.yaml
+++ b/modules/s3/tests/integration.yaml
@@ -220,13 +220,17 @@
 
         @runner()
         @output("test.txt", dst_dir="output", dst_name="sample_test.txt")
+        @output("test_dir")
         def a(samples, workdir, **_):
             (workdir / "test.txt").touch()
+            (workdir / "test_dir").mkdir()
+            (workdir / "test_dir" / "nested.txt").touch()
     input:
       TEST: TEST
   logs:
     - Uploading output to s3://test-bucket/uploaded
     - Uploaded test.txt to s3://test-bucket/uploaded/output/sample_test.txt
+    - Uploaded nested.txt to s3://test-bucket/uploaded/test_dir/nested.txt
     - Finished uploading output to S3
 
 - <<: *s3_upload_test


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What

Makes the S3 upload post-hook traverse output directories.

### The Why

The current implementation does not upload the contents of directories specified as runner outputs.
Instead, it reports an error.

### The How
* Instead of iterating through `samples.output` directly, copies everything into stack
* Pops current output
* Pushes files in output directories onto stack instead of trying to upload directory

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests

### Expected outcome

## Verifications
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat